### PR TITLE
添加一个参数，使客户端可以不删除在服务器端不存在的文件

### DIFF
--- a/common/src/main/java/org/skycraft/updater/core/Provider.java
+++ b/common/src/main/java/org/skycraft/updater/core/Provider.java
@@ -92,6 +92,7 @@ public final class Provider implements Runnable, Closeable {
 				writer.beginObject();
 				String category = null;
 				Path path = null;
+				boolean removeUntracked = true;
 				while (reader.hasNext()) {
 					switch (reader.nextName()) {
 					case "category":
@@ -106,6 +107,10 @@ public final class Provider implements Runnable, Closeable {
 							return false;
 						}
 						writer.name("path").value(path.toString());
+						break;
+					case "removeUntracked":
+						removeUntracked = reader.nextBoolean();
+						writer.name("removeUntracked").value(removeUntracked);
 						break;
 					default:
 						logger.log(Level.WARNING, "Illegal manifest format");


### PR DESCRIPTION
主要用于更新config目录的配置等
因为服务器端只有有必要修改的配置文件才放到config目录下
如果按照以前的方式更新mod会删除很多自动生成的配置文件

同样也可用于更新客户端的资源包、数据包等
这样不会主动删除用户自己安装的资源包、数据包

Provider那里为了尽量减少修改点采用了一些不太干净的方式，有做 TODO 标记, 如允许 可以再pr一个稍微干净一点的修改